### PR TITLE
Nasty hack to deal with the fact that the URLs are case sensitive

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -1,0 +1,5 @@
+<script>
+    window.onload = () => {
+        location.replace(window.location.href.replace('cfp', 'CFP'))
+    };
+</script>

--- a/cfw.html
+++ b/cfw.html
@@ -1,0 +1,5 @@
+<script>
+    window.onload = () => {
+        location.replace(window.location.href.replace('cfw', 'CFW'))
+    };
+</script>


### PR DESCRIPTION
GitHub pages are case sensitive so the CFW and CFP pages are only accessible when using uppercase. 

This is a quick and dirty hack to redirect to the correct pages if the lower case version is used.

Obviously it does not handle any other pages.

If you use mixed case for these pages, you are on your own....